### PR TITLE
Re-Write for User Preferences and Grep Issues

### DIFF
--- a/lib/facter/current_user.rb
+++ b/lib/facter/current_user.rb
@@ -1,0 +1,10 @@
+#
+# Credit to Graham Gilbert for this fact.
+# current_user.rb
+#
+Facter.add('current_user') do
+  confine kernel: 'Darwin'
+  setcode do
+    Facter::Util::Resolution.exec('/bin/ls -l /dev/console').split(' ')[2]
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,5 +38,8 @@ define macdefaults($domain, $key, $value = false, $type = 'string', $action = 'w
         }
       }
     }
+    default: {
+      fail('Incorrect OS Used. Please use macOS only.')
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,7 +51,6 @@ define macdefaults($domain, $key, $value = false, $type = 'string', $action = 'w
       }
     }
     default: {
-      fail('Incorrect OS Used. Please use macOS only.')
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,45 +1,46 @@
 # Note that type can be one of:
 # string, data, int, float, bool, data, array, array-add, dict, dict-add
-define macdefaults($domain, $key, $value = false, $type = 'string', $action = 'write') {
+define macdefaults($domain, $key, $value = false, $type = 'string', $action = 'write', $runas = 'root') {
 
-  case $type {
-    'bool': {
-      if $value {
-        $write_value = 'TRUE'
-      }
-      else {
-        $write_value = 'FALSE'
-      }
+  if $runas != 'root' {
+    $user = $::current_user
+  }
+
+  case $value {
+    true : {
+      $grep = 1
+    }
+    false : {
+      $grep = 0
     }
     default: {
-      $write_value = $value
+      $grep = $value
     }
   }
 
-  case $operatingsystem {
-   'Darwin':{
-    case $action {
-      'write': {
-        exec {"/usr/bin/defaults write ${domain} ${key} -${type} '${write_value}'":
-            unless => $type ? {
-              'bool' => $value ? {
-                true  => "/usr/bin/defaults read ${domain} ${key} | /usr/bin/grep -qx 1",
-                false => "/usr/bin/defaults read ${domain} ${key} | /usr/bin/grep -qx 0"
-                },
-            default  => "/usr/bin/defaults read ${domain} ${key} | /usr/bin/grep -qx ${value}"
+  case $::operatingsystem {
+    'Darwin':{
+      case $action {
+        'write': {
+          exec { "/usr/bin/defaults write ${domain} ${key} -${type} '${value}'":
+            user   => $user
+            unless => "/usr/bin/defaults read ${domain} ${key} | /usr/bin/grep -qx '${grep}'"
           }
         }
-      }
       'delete': {
-        exec {"/usr/bin/defaults delete ${domain} ${key}":
+        exec { "/usr/bin/defaults delete ${domain} ${key}":
           logoutput => false,
           onlyif    => "/usr/bin/defaults read ${domain} | /usr/bin/grep -q '${key}'"
         }
       }
+      default: {
+        fail('Only write and delete are supported values for action.')
+      }
     }
-   }
+
+    default: {
+      fail('Only supported OS is Darwin')
+    }
+    }
   }
-
-
 }
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@ define macdefaults($domain, $key, $value = false, $type = 'string', $action = 'w
         'write': {
           exec { "/usr/bin/defaults write ${domain} ${key} -${type} '${value}'":
             user   => $user,
-            unless => "/usr/bin/defaults read ${domain} ${key} | /usr/bin/grep -qx '${grep}'"
+            unless => "/usr/bin/defaults read ${domain} ${key} | /usr/bin/grep -q '${grep}'"
           }
         }
         'delete': {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,20 +27,19 @@ define macdefaults($domain, $key, $value = false, $type = 'string', $action = 'w
             unless => "/usr/bin/defaults read ${domain} ${key} | /usr/bin/grep -qx '${grep}'"
           }
         }
-      'delete': {
-        exec { "/usr/bin/defaults delete ${domain} ${key}":
-          logoutput => false,
-          onlyif    => "/usr/bin/defaults read ${domain} | /usr/bin/grep -q '${key}'"
+        'delete': {
+          exec { "/usr/bin/defaults delete ${domain} ${key}":
+            logoutput => false,
+            onlyif    => "/usr/bin/defaults read ${domain} | /usr/bin/grep -q '${key}'"
+          }
+        }
+        default: {
+          fail('Only write and delete are supported values for action.')
         }
       }
       default: {
-        fail('Only write and delete are supported values for action.')
+        fail('Only supported OS is Darwin')
       }
-    }
-
-    default: {
-      fail('Only supported OS is Darwin')
-    }
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,9 +37,6 @@ define macdefaults($domain, $key, $value = false, $type = 'string', $action = 'w
           fail('Only write and delete are supported values for action.')
         }
       }
-      default: {
-        fail('Only supported OS is Darwin')
-      }
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ define macdefaults($domain, $key, $value = false, $type = 'string', $action = 'w
       case $action {
         'write': {
           exec { "/usr/bin/defaults write ${domain} ${key} -${type} '${value}'":
-            user   => $user
+            user   => $user,
             unless => "/usr/bin/defaults read ${domain} ${key} | /usr/bin/grep -qx '${grep}'"
           }
         }


### PR DESCRIPTION
I have added the ability to run as the user to access user specific preferences. Also corrected an issue with grep causing it to fail with strings or preference domains that contained a space in them. Also cleaned up code based on current puppet style guidelines. Tested with real bools, array-add and string with no issues.

This adds an option that can be passed to macdefaults:

runas

This should take one option => 'user' or 'root'

Thanks,
Ed